### PR TITLE
Fix compile errors on Linux

### DIFF
--- a/include/vapp.h
+++ b/include/vapp.h
@@ -3,6 +3,10 @@
 
 #include "vgl.h"
 
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+
 class VermilionApplication
 {
 protected:

--- a/include/vec.h
+++ b/include/vec.h
@@ -11,7 +11,7 @@
 #  define _USE_MATH_DEFINES 1
 #endif
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 const float  DegreesToRadians = static_cast<float>(M_PI / 180.0f);

--- a/lib/LoadShaders.cpp
+++ b/lib/LoadShaders.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <cstdio>
 
 #include <GL3/gl3w.h>
 #include "LoadShaders.h"

--- a/lib/vbm.cpp
+++ b/lib/vbm.cpp
@@ -4,6 +4,7 @@
 #include "vgl.h"
 
 #include <stdio.h>
+#include <string.h>
 
 VBObject::VBObject(void)
     : m_vao(0),

--- a/lib/vdds.cpp
+++ b/lib/vdds.cpp
@@ -602,44 +602,47 @@ void vglLoadDDS(const char* filename, vglImageData* image)
 
     if (image->target == GL_NONE)
         goto done_close_file;
-
-    size_t current_pos = ftell(f);
-    size_t file_size;
-    fseek(f, 0, SEEK_END);
-    file_size = ftell(f);
-    fseek(f, (long)current_pos, SEEK_SET);
-
-    image->totalDataSize = file_size - current_pos;
-    image->mip[0].data = new uint8_t [image->totalDataSize];
-
-    fread(image->mip[0].data, file_size - current_pos, 1, f);
-
-    int level;
-    GLubyte * ptr = reinterpret_cast<GLubyte*>(image->mip[0].data);
-
-    int width = file_header.std_header.width;
-    int height = file_header.std_header.height;
-    int depth = file_header.std_header.depth;
-
-    image->sliceStride = 0;
-
-    if (image->mipLevels == 0)
+    
     {
-        image->mipLevels = 1;
-    }
+        size_t current_pos = ftell(f);
+        size_t file_size;
+        fseek(f, 0, SEEK_END);
+        file_size = ftell(f);
+        fseek(f, (long)current_pos, SEEK_SET);
 
-    for (level = 0; level < image->mipLevels; ++level)
-    {
-        image->mip[level].data = ptr;
-        image->mip[level].width = width;
-        image->mip[level].height = height;
-        image->mip[level].depth = depth;
-        image->mip[level].mipStride = vgl_GetDDSStride(file_header, width) * height;
-        image->sliceStride += image->mip[level].mipStride;
-        ptr += image->mip[level].mipStride;
-        width >>= 1;
-        height >>= 1;
-        depth >>= 1;
+        image->totalDataSize = file_size - current_pos;
+        image->mip[0].data = new uint8_t [image->totalDataSize];
+
+        fread(image->mip[0].data, file_size - current_pos, 1, f);
+
+        int level;
+        GLubyte * ptr = reinterpret_cast<GLubyte*>(image->mip[0].data);
+
+        int width = file_header.std_header.width;
+        int height = file_header.std_header.height;
+        int depth = file_header.std_header.depth;
+
+        image->sliceStride = 0;
+
+        if (image->mipLevels == 0)
+        {
+            image->mipLevels = 1;
+        }
+
+        for (level = 0; level < image->mipLevels; ++level)
+        {
+            image->mip[level].data = ptr;
+            image->mip[level].width = width;
+            image->mip[level].height = height;
+            image->mip[level].depth = depth;
+            image->mip[level].mipStride = vgl_GetDDSStride(file_header, width) * height;
+            image->sliceStride += image->mip[level].mipStride;
+            ptr += image->mip[level].mipStride;
+            width >>= 1;
+            height >>= 1;
+            depth >>= 1;
+        }
+
     }
 
 done_close_file:

--- a/src/10-fur/10-fur.cpp
+++ b/src/10-fur/10-fur.cpp
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 BEGIN_APP_DECLARATION(FurApplication)
     // Override functions from base class

--- a/src/11-doublewrite/11-doublewrite.cpp
+++ b/src/11-doublewrite/11-doublewrite.cpp
@@ -14,6 +14,7 @@
 #include "LoadShaders.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <string>
 
 #define MAX_FRAMEBUFFER_WIDTH 2048

--- a/src/11-oit/11-oit.cpp
+++ b/src/11-oit/11-oit.cpp
@@ -14,6 +14,7 @@
 #include "LoadShaders.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <string>
 
 #define MAX_FRAMEBUFFER_WIDTH 2048

--- a/src/11-overdrawcount/11-overdrawcount.cpp
+++ b/src/11-overdrawcount/11-overdrawcount.cpp
@@ -14,6 +14,7 @@
 #include "LoadShaders.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <string>
 
 #define MAX_FRAMEBUFFER_WIDTH 2048

--- a/src/12-particlesimulator/12-particlesimulator.cpp
+++ b/src/12-particlesimulator/12-particlesimulator.cpp
@@ -111,7 +111,7 @@ void ComputeParticleSimulator::Initialize(const char * title)
 
     static const char compute_shader_source[] =
         STRINGIZE(
-#version 430 core\n
+version 430 core\n
 
 layout (std140, binding = 0) uniform attractor_block
 {


### PR DESCRIPTION
The changes below fix compile errors experienced on Ubuntu 16.04 LTS
with GCC 5.4.0.

- On Linux, <sys/time.h> must be included to make struct timeval known.
- <math.h> does not include `std:sqrt`. `<cmath>` does.
- <cstdio> must be included to use fopen().
- string.h must be included to use memset().
- A jump to a label (done_close_file) must not cross local
  declarations. The corresponding code has been encapsulated in a block.
- The use of the STRINGIZE macro leads to an error where the compiler
  sees the #version 430 sequence as an invalid preprocessor directive.
  Removing the # from #version fixes this.